### PR TITLE
Add Symbol order book ticker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This implementation has been developed as a consequence of the lack of suitable 
 - [Aggregate trades list](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#compressedaggregate-trades-list) -> `api::agg_trades()`
 - [24hr ticker price change statistics](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#24hr-ticker-price-change-statistics) -> `api::_24hrs_ticker()`
 - [Symbol price ticker](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#symbol-price-ticker) -> `api::price()`
+- [Symbol order book ticker](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#symbol-order-book-ticker) -> `api::bookTicker()`
 - [New order](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#new-order--trade) -> `api::new_order()`
 - [Query order](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#query-order-user_data) -> `api::order_info()`
 - [Test new order](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#test-new-order-trade) -> `api::new_test_order()`

--- a/include/binapi/api.hpp
+++ b/include/binapi/api.hpp
@@ -113,6 +113,17 @@ struct api {
     result<prices_t>
     prices(prices_cb cb = {});
 
+    // https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#symbol-order-book-ticker
+    using bookTicker_cb = std::function<bool(const char* fl, int ec, std::string errmsg, booktickers_t::bookticker_t res)>;
+    result<booktickers_t::bookticker_t>
+    bookTicker(const std::string& symbol, bookTicker_cb cb = {}) { return bookTicker(symbol.c_str(), std::move(cb)); }
+    result<booktickers_t::bookticker_t>
+    bookTicker(const char* symbol, bookTicker_cb cb = {});
+
+    using bookTickers_cb = std::function<bool(const char* fl, int ec, std::string errmsg, booktickers_t res)>;
+    result<booktickers_t>
+    bookTicker(bookTickers_cb cb = {});
+
     // https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#current-average-price
     using avg_price_cb = std::function<bool(const char *fl, int ec, std::string errmsg, avg_price_t res)>;
     result<avg_price_t>

--- a/include/binapi/types.hpp
+++ b/include/binapi/types.hpp
@@ -82,6 +82,37 @@ struct prices_t {
     const price_t& get_by_symbol(const char *sym) const;
 };
 
+// https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#symbol-order-book-ticker
+struct booktickers_t {
+    struct bookticker_t {
+        std::string symbol;
+        double_type bidPrice;
+        double_type bidQty;
+        double_type askPrice;
+        double_type askQty;
+
+        static bookticker_t construct(const flatjson::fjson& json);
+        friend std::ostream& operator<<(std::ostream& os, const bookticker_t& f);
+    };
+
+    static booktickers_t construct(const flatjson::fjson& json);
+    friend std::ostream& operator<<(std::ostream& os, const booktickers_t& f);
+
+    std::map<std::string, bookticker_t> prices;
+
+    bool is_valid_symbol(const std::string& sym) const
+    {
+        return is_valid_symbol(sym.c_str());
+    }
+    bool is_valid_symbol(const char* sym) const;
+
+    const bookticker_t& get_by_symbol(const std::string& sym) const
+    {
+        return get_by_symbol(sym.c_str());
+    }
+    const bookticker_t& get_by_symbol(const char* sym) const;
+};
+
 // https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#24hr-ticker-price-change-statistics
 struct _24hrs_tickers_t {
     struct _24hrs_ticker_t {

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -644,6 +644,22 @@ api::result<prices_t> api::prices(prices_cb cb) {
 
 /*************************************************************************************************/
 
+api::result<booktickers_t::bookticker_t> api::bookTicker(const char* symbol, bookTicker_cb cb)
+{
+    const impl::init_list_type map = {
+        { "symbol", symbol }
+    };
+
+    return pimpl->post(false, "/api/v3/ticker/bookTicker", boost::beast::http::verb::get, map, std::move(cb));
+}
+
+api::result<booktickers_t> api::bookTicker(bookTickers_cb cb)
+{
+    return pimpl->post(false, "/api/v3/ticker/bookTicker", boost::beast::http::verb::get, {}, std::move(cb));
+}
+
+/*************************************************************************************************/
+
 api::result<avg_price_t> api::avg_price(const char *symbol, avg_price_cb cb) {
     const impl::init_list_type map = {
         {"symbol", symbol}

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -188,6 +188,84 @@ const prices_t::price_t& prices_t::get_by_symbol(const char *sym) const {
 
 /*************************************************************************************************/
 
+booktickers_t::bookticker_t booktickers_t::bookticker_t::construct(const flatjson::fjson& json)
+{
+    assert(json.is_valid());
+
+    booktickers_t::bookticker_t res {};
+    __BINAPI_GET(symbol);
+    __BINAPI_GET(bidPrice);
+    __BINAPI_GET(bidQty);
+    __BINAPI_GET(askPrice);
+    __BINAPI_GET(askQty);
+
+    return res;
+}
+
+std::ostream& operator<<(std::ostream& os, const booktickers_t::bookticker_t& o)
+{
+    os
+        << "{"
+        << "\"symbol\":\"" << o.symbol << "\","
+        << "\"bidPrice\":\"" << o.bidPrice << "\","
+        << "\"bidQty\":\"" << o.bidQty << "\","
+        << "\"askPrice\":\"" << o.askPrice << "\""
+        << "\"askQty\":\"" << o.askQty << "\""
+        << "}";
+
+    return os;
+}
+
+/*************************************************************************************************/
+
+booktickers_t booktickers_t::construct(const flatjson::fjson& json)
+{
+    assert(json.is_valid());
+    assert(json.is_array());
+
+    booktickers_t res {};
+    for (auto idx = 0u; idx < json.size(); ++idx) {
+        auto item = booktickers_t::bookticker_t::construct(json[idx]);
+        std::string symbol = item.symbol;
+        res.prices.emplace(std::move(symbol), std::move(item));
+    }
+
+    return res;
+}
+
+std::ostream& operator<<(std::ostream& os, const booktickers_t& o)
+{
+    os
+        << "[";
+    for (auto it = o.prices.begin(); it != o.prices.end(); ++it) {
+        os << it->second;
+        if (std::next(it) != o.prices.end()) {
+            os << ",";
+        }
+    }
+
+    os
+        << "]";
+
+    return os;
+}
+
+bool booktickers_t::is_valid_symbol(const char* sym) const
+{
+    return prices.find(sym) != prices.end();
+}
+
+const booktickers_t::bookticker_t& booktickers_t::get_by_symbol(const char* sym) const
+{
+    auto it = prices.find(sym);
+    if (it != prices.end()) {
+        return it->second;
+    }
+
+    assert(!"unreachable");
+}
+
+/*************************************************************************************************/
 _24hrs_tickers_t::_24hrs_ticker_t
 _24hrs_tickers_t::_24hrs_ticker_t::construct(const flatjson::fjson &json) {
     assert(json.is_valid());


### PR DESCRIPTION
Hi I've been using your API (which is great by the way) and I noticed you didn't support the symbol order book ticker.

https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#symbol-order-book-ticker