### PR TITLE
add api::common_str

### DIFF
--- a/include/binapi/api.hpp
+++ b/include/binapi/api.hpp
@@ -113,6 +113,14 @@ struct api {
     result<prices_t>
     prices(prices_cb cb = {});
 
+    using common_str_cb = std::function<bool(const char* fl, int ec, std::string errmsg, common_strs_t res)>;
+    result<common_strs_t>
+    common_str(
+        std::string str_url, 
+        std::initializer_list<std::pair<const char*, boost::variant<std::size_t, const char*>>> map = {},
+        common_str_cb cb = {}
+    );
+
     // https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#current-average-price
     using avg_price_cb = std::function<bool(const char *fl, int ec, std::string errmsg, avg_price_t res)>;
     result<avg_price_t>

--- a/include/binapi/types.hpp
+++ b/include/binapi/types.hpp
@@ -82,6 +82,21 @@ struct prices_t {
     const price_t& get_by_symbol(const char *sym) const;
 };
 
+struct common_strs_t {
+    struct common_str_t {
+        std::string symbol;     //useless now
+        std::string str_return;
+
+        static common_str_t construct(const flatjson::fjson& json);
+        friend std::ostream& operator<<(std::ostream& os, const common_str_t& f);
+    };
+
+    std::map<std::string, common_str_t> tickers;
+
+    static common_strs_t construct(const flatjson::fjson& json);
+    friend std::ostream& operator<<(std::ostream& os, const common_strs_t& f);
+};
+
 // https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#24hr-ticker-price-change-statistics
 struct _24hrs_tickers_t {
     struct _24hrs_ticker_t {

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -351,6 +351,7 @@ struct api::impl {
 
                         return res;
                     } else {
+                        //std::cout << typeid(R).name() << std::endl;
                         res.v = R::construct(json);
                     }
                 }
@@ -716,6 +717,16 @@ api::result<prices_t::price_t> api::price(const char *symbol, price_cb cb) {
 
 api::result<prices_t> api::prices(prices_cb cb) {
     return pimpl->post(false, "/api/v3/ticker/price", boost::beast::http::verb::get, {}, std::move(cb));
+}
+
+/*************************************************************************************************/
+
+api::result<common_strs_t> api::common_str(
+    std::string str_url,
+    std::initializer_list<std::pair<const char*, boost::variant<std::size_t, const char*>>> map,
+    common_str_cb cb) 
+{
+    return pimpl->post(false, str_url.c_str(), boost::beast::http::verb::get, map, std::move(cb));
 }
 
 /*************************************************************************************************/

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -16,6 +16,7 @@
 #include <type_traits>
 
 #include <boost/utility/string_view.hpp>
+#include <iostream>
 
 //#include <iostream> // TODO: comment out
 
@@ -187,6 +188,50 @@ const prices_t::price_t& prices_t::get_by_symbol(const char *sym) const {
     }
 
     assert(!"unreachable");
+}
+
+/*************************************************************************************************/
+
+common_strs_t::common_str_t
+common_strs_t::common_str_t::construct(const flatjson::fjson& json) {
+    if (!json.is_valid()) {     //pure json, differnt with others
+        std::cout << "common_strs_t::common_str_t::construct error, not valid" << std::endl;
+    }
+
+    common_strs_t::common_str_t res{};
+
+    res.symbol = (json.is_object() && json.contains("symbol")) ? json["symbol"].to_string() : "";
+    //res.symbol = "";
+    res.str_return = json.dump();
+    
+    return res;
+}
+
+std::ostream& operator<<(std::ostream& os, const common_strs_t::common_str_t& f) {
+    os
+        << "{"
+        << "\"symbol\":\"" << f.symbol << "\","
+        << "\"str_return\":" << f.str_return
+        << "}";
+
+    return os;
+}
+
+common_strs_t common_strs_t::construct(const flatjson::fjson& json) {
+    if (!json.is_valid()) {     //pure json, differnt with others
+        std::cout << "common_strs_t::construct error, not valid" <<std::endl;
+    }
+
+    common_strs_t res{};
+    res.tickers.emplace(std::string("common_str"), common_strs_t::common_str_t::construct(json));
+    
+    return res;
+}
+
+std::ostream& operator<<(std::ostream& os, const common_strs_t& f) {
+    os << f.tickers.at("common_str").str_return;
+
+    return os;
 }
 
 /*************************************************************************************************/


### PR DESCRIPTION
Add common str post for other request like fapi.

Here is a sample:
use url "fapi.binance.com" instead of "api.binance.com"

~~~
        auto res0 = api.common_str("/fapi/v1/trades", { {"symbol","BNBUSDT"} });
        if (res0) std::cout << "api.common_str /fapi/v1/trades: " << res0.v << std::endl;
~~~

You can parse the json string by yourself.
The code is not elegant, but it can be used.