### PR TITLE
added static library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,12 +47,14 @@ set(BINAPI_SOURCES
     src/websocket.cpp
 )
 
+add_library(${PROJECT_NAME}_static STATIC
+    ${BINAPI_SOURCES}
+    )
+
 add_executable(
     ${PROJECT_NAME}
     #
     main.cpp
-    #
-    ${BINAPI_SOURCES}
 )
 
 if (DEFINED ${BOOST_LIB_DIR})
@@ -64,6 +66,7 @@ endif()
 
 target_link_libraries(
     ${PROJECT_NAME}
+    lib${PROJECT_NAME}_static.a
     z
     crypto
     ssl


### PR DESCRIPTION
With this tiny change one can easily integrate this repo as a submodule without need to build it complete and modifying source lists.

Example of top level repo CMakeLists.txt:

include_directories(
    ./binapi/include
)

add_subdirectory(binapi EXCLUDE_FROM_ALL)

add_executable(
    ${PROJECT_NAME}
    #
    main.cpp
)

add_dependencies(${PROJECT_NAME}
    binapi_static
    )

target_link_directories(${PROJECT_NAME}
    PUBLIC 
    ${CMAKE_BINARY_DIR}/binapi
    )

target_link_libraries(${PROJECT_NAME}
    libbinapi_static.a
    z
    crypto
    ssl
    pthread
    )

